### PR TITLE
Have the redirects prefix added automatically

### DIFF
--- a/redirects.yml
+++ b/redirects.yml
@@ -1,4 +1,4 @@
 redirects:
-  /r/something: https://github.com/itspngu/cloudflare-redirect-worker
-  /r/copr: https://copr.fedorainfracloud.org/coprs/itspngu/
-  /r/test: https://www.npmjs.com/package/yaml-loader#usage
+  something: https://github.com/itspngu/cloudflare-redirect-worker
+  copr: https://copr.fedorainfracloud.org/coprs/itspngu/
+  test: https://www.npmjs.com/package/yaml-loader#usage

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,12 @@
 // @ts-expect-error
 import { redirects, prefix } from "../redirects.yml";
 
-const redirectPrefix: string = prefix || "/r/";
+const redirectPrefix: string = prefix || "/r";
 const redirectsTyped = redirects as Record<string, string>;
 
 const redirectsPrefixed: [string, string][] = Object.entries(
     redirectsTyped,
-).map(([route, redirect]) => [`${redirectPrefix}${route}`, redirect]);
+).map(([route, redirect]) => [`${redirectPrefix}/${route}`, redirect]);
 
 const redirectMap: Map<string, string> = new Map(redirectsPrefixed);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,12 @@
 // @ts-expect-error
-import { redirects } from "../redirects.yml";
+import {redirects} from "../redirects.yml";
 
-const redirectMap: Map<string, string> = new Map(Object.entries(redirects));
+const redirectsTyped = redirects as Record<string,string>;
+const redirectsPrefixed: [string, string][] = Object.entries(redirectsTyped).map(
+    ([route, redirect]) => [`/r/${route}`, redirect]
+);
+
+const redirectMap: Map <string, string> = new Map(redirectsPrefixed);
 
 async function handleRequest(req: Request): Promise<Response> {
     console.log(redirects);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,14 @@
 // @ts-expect-error
-import {redirects} from "../redirects.yml";
+import { redirects, prefix } from "../redirects.yml";
 
-const redirectsTyped = redirects as Record<string,string>;
-const redirectsPrefixed: [string, string][] = Object.entries(redirectsTyped).map(
-    ([route, redirect]) => [`/r/${route}`, redirect]
-);
+const redirectPrefix: string = prefix || "/r/";
+const redirectsTyped = redirects as Record<string, string>;
 
-const redirectMap: Map <string, string> = new Map(redirectsPrefixed);
+const redirectsPrefixed: [string, string][] = Object.entries(
+    redirectsTyped,
+).map(([route, redirect]) => [`${redirectPrefix}${route}`, redirect]);
+
+const redirectMap: Map<string, string> = new Map(redirectsPrefixed);
 
 async function handleRequest(req: Request): Promise<Response> {
     console.log(redirects);


### PR DESCRIPTION
This reduces clutter in the redirects.yml file

I also added an optional prefix override to redirects.yml incase /r/ needs to be changed

No idea if it works as untested